### PR TITLE
Add tech stack icon showcase to skills section

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -553,6 +553,84 @@ nav {
   font-size: 1rem;
 }
 
+.tech-stack-showcase {
+  margin: 0 auto 3.5rem auto;
+  padding: 2.25rem 2.75rem;
+  border-radius: 2rem;
+  background: linear-gradient(135deg, rgba(99, 102, 241, 0.12), rgba(14, 165, 233, 0.1));
+  border: 1px solid rgba(99, 102, 241, 0.15);
+  box-shadow: 0 24px 50px rgba(15, 23, 42, 0.12);
+}
+
+.tech-stack-title {
+  text-transform: uppercase;
+  letter-spacing: 0.28em;
+  font-size: 0.8rem;
+  color: var(--primary-color);
+  font-weight: 700;
+  text-align: center;
+}
+
+.tech-icon-grid {
+  margin-top: 1.75rem;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 1.5rem;
+}
+
+.tech-icon-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 1.4rem 1rem;
+  border-radius: 1.25rem;
+  background: rgba(255, 255, 255, 0.75);
+  border: 1px solid rgba(99, 102, 241, 0.12);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45),
+    0 12px 24px rgba(15, 23, 42, 0.08);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+}
+
+.tech-icon-card img {
+  width: 52px;
+  height: 52px;
+  object-fit: contain;
+  transition: transform 0.3s ease;
+}
+
+.tech-icon-card figcaption {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--text-color);
+  text-align: center;
+}
+
+.tech-icon-card:hover,
+.tech-icon-card:focus-within {
+  transform: translateY(-6px);
+  box-shadow: 0 18px 35px rgba(99, 102, 241, 0.22);
+}
+
+.tech-icon-card:hover img,
+.tech-icon-card:focus-within img {
+  transform: scale(1.08);
+}
+
+.tech-icon-card:focus-within figcaption {
+  text-decoration: underline;
+  text-decoration-color: rgba(99, 102, 241, 0.45);
+  text-decoration-thickness: 2px;
+  text-underline-offset: 4px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .tech-icon-card,
+  .tech-icon-card img {
+    transition: none;
+  }
+}
+
 .skills-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));

--- a/index.html
+++ b/index.html
@@ -444,8 +444,110 @@
           <p class="skills-intro">
             A toolbox shaped by enterprise product delivery: scalable backend
             services, resilient infrastructure, and immersive interfaces that
-            prioritize user outcomes.
+            prioritize user outcomes. Here are the platforms and frameworks I
+            lean on daily.
           </p>
+          <div class="tech-stack-showcase" aria-label="Core technology stack">
+            <h3 class="tech-stack-title">Daily Drivers</h3>
+            <div class="tech-icon-grid">
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Java.svg"
+                  alt="Java logo"
+                  loading="lazy"
+                />
+                <figcaption>Java</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Spring.svg"
+                  alt="Spring Framework logo"
+                  loading="lazy"
+                />
+                <figcaption>Spring</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/React.svg"
+                  alt="React logo"
+                  loading="lazy"
+                />
+                <figcaption>React</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/TypeScript.svg"
+                  alt="TypeScript logo"
+                  loading="lazy"
+                />
+                <figcaption>TypeScript</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Node.js.svg"
+                  alt="Node.js logo"
+                  loading="lazy"
+                />
+                <figcaption>Node.js</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Python.svg"
+                  alt="Python logo"
+                  loading="lazy"
+                />
+                <figcaption>Python</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Docker.svg"
+                  alt="Docker logo"
+                  loading="lazy"
+                />
+                <figcaption>Docker</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/Kubernetes.svg"
+                  alt="Kubernetes logo"
+                  loading="lazy"
+                />
+                <figcaption>Kubernetes</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/AWS.svg"
+                  alt="AWS logo"
+                  loading="lazy"
+                />
+                <figcaption>AWS</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/HashiCorp-Terraform.svg"
+                  alt="Terraform logo"
+                  loading="lazy"
+                />
+                <figcaption>Terraform</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/PostgresSQL.svg"
+                  alt="PostgreSQL logo"
+                  loading="lazy"
+                />
+                <figcaption>PostgreSQL</figcaption>
+              </figure>
+              <figure class="tech-icon-card">
+                <img
+                  src="./assets/images/tech-stack-icons/MongoDB.svg"
+                  alt="MongoDB logo"
+                  loading="lazy"
+                />
+                <figcaption>MongoDB</figcaption>
+              </figure>
+            </div>
+          </div>
           <div class="skills-grid">
             <div class="skill-category">
               <h3>Core Engineering</h3>


### PR DESCRIPTION
## Summary
- introduce a daily drivers showcase in the skills section using the curated tech stack SVG icons
- style the new icon grid with hover states, accessibility improvements, and reduced motion support
- update the skills introduction copy to reference the highlighted tooling

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d40dc0b86c83338b80c02374a1339b