### PR TITLE
Fix asset paths for static build

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,5 +5,11 @@ import react from '@astrojs/react';
 
 // https://astro.build/config
 export default defineConfig({
-  integrations: [react()]
+  integrations: [react()],
+  vite: {
+    base: './',
+  },
+  build: {
+    assetsPrefix: '.',
+  },
 });

--- a/src/components/Welcome.astro
+++ b/src/components/Welcome.astro
@@ -66,7 +66,7 @@
             >
               <div class="hero-profile">
                 <img
-                  src="/images/me.png"
+                  src="images/me.png"
                   alt="Portrait of Ahmed Marzook"
                 />
               </div>
@@ -81,7 +81,7 @@
           <div class="about-content">
             <div class="about-visual" data-reveal="left">
               <img
-                src="/images/me.png"
+                src="images/me.png"
                 alt="Ahmed smiling"
                 class="about-image"
               />
@@ -157,7 +157,7 @@
             <div class="project-card" data-reveal>
               <div class="project-media">
                 <img
-                  src="/images/birth-your-way.png"
+                  src="images/birth-your-way.png"
                   alt="Birth Your Way birth plan generator placeholder"
                 />
               </div>
@@ -172,7 +172,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -181,7 +181,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/TypeScript.svg"
+                      src="images/tech-stack-icons/TypeScript.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -190,7 +190,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Vite.svg"
+                      src="images/tech-stack-icons/Vite.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -199,7 +199,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Azure.svg"
+                      src="images/tech-stack-icons/Azure.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -208,7 +208,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/NPM.svg"
+                      src="images/tech-stack-icons/NPM.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -234,7 +234,7 @@
             >
               <div class="project-media">
                 <img
-                  src="/images/lastlang.png"
+                  src="images/lastlang.png"
                   alt="Screenshot from The Last High-Level Language game"
                 />
               </div>
@@ -249,7 +249,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -258,7 +258,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/JavaScript.svg"
+                      src="images/tech-stack-icons/JavaScript.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -267,7 +267,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Vite.svg"
+                      src="images/tech-stack-icons/Vite.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -276,7 +276,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/NPM.svg"
+                      src="images/tech-stack-icons/NPM.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -304,7 +304,7 @@
             <div class="project-card" data-reveal style="--reveal-delay: 0.1s">
               <div class="project-media">
                 <img
-                  src="/images/tenzies.png"
+                  src="images/tenzies.png"
                   alt="Tenzies dice game interface"
                 />
               </div>
@@ -319,7 +319,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -328,7 +328,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/JavaScript.svg"
+                      src="images/tech-stack-icons/JavaScript.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -337,7 +337,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Vite.svg"
+                      src="images/tech-stack-icons/Vite.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -346,7 +346,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/NPM.svg"
+                      src="images/tech-stack-icons/NPM.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -378,7 +378,7 @@
             >
               <div class="project-media">
                 <img
-                  src="/images/weather-bridge.jpg"
+                  src="images/weather-bridge.jpg"
                   alt="WeatherBridge API dashboard placeholder"
                 />
               </div>
@@ -393,7 +393,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Java.svg"
+                      src="images/tech-stack-icons/Java.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -402,7 +402,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Spring.svg"
+                      src="images/tech-stack-icons/Spring.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -411,7 +411,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Redis.svg"
+                      src="images/tech-stack-icons/Redis.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -420,7 +420,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/AWS.svg"
+                      src="images/tech-stack-icons/AWS.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -429,7 +429,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -438,7 +438,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/HashiCorp-Terraform.svg"
+                      src="images/tech-stack-icons/HashiCorp-Terraform.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -475,7 +475,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Java.svg"
+                      src="images/tech-stack-icons/Java.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -484,7 +484,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Spring.svg"
+                      src="images/tech-stack-icons/Spring.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -493,7 +493,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/MongoDB.svg"
+                      src="images/tech-stack-icons/MongoDB.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -502,7 +502,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -543,7 +543,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Java.svg"
+                      src="images/tech-stack-icons/Java.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -552,7 +552,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Spring.svg"
+                      src="images/tech-stack-icons/Spring.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -561,7 +561,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/PostgresSQL.svg"
+                      src="images/tech-stack-icons/PostgresSQL.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -570,7 +570,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -607,7 +607,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Java.svg"
+                      src="images/tech-stack-icons/Java.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -616,7 +616,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/Spring.svg"
+                      src="images/tech-stack-icons/Spring.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -625,7 +625,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/PostgresSQL.svg"
+                      src="images/tech-stack-icons/PostgresSQL.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -634,7 +634,7 @@
                   </span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -675,7 +675,7 @@
                 <div class="project-tags">
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/React.svg"
+                      src="images/tech-stack-icons/React.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -685,7 +685,7 @@
                   <span class="tag">Expo</span>
                   <span class="tag">
                     <img
-                      src="/images/tech-stack-icons/TypeScript.svg"
+                      src="images/tech-stack-icons/TypeScript.svg"
                       alt=""
                       aria-hidden="true"
                       loading="lazy"
@@ -730,7 +730,7 @@
                 style="--reveal-delay: 0.12s"
               >
                 <img
-                  src="/images/tech-stack-icons/Java.svg"
+                  src="images/tech-stack-icons/Java.svg"
                   alt="Java logo"
                   loading="lazy"
                 />
@@ -742,7 +742,7 @@
                 style="--reveal-delay: 0.17s"
               >
                 <img
-                  src="/images/tech-stack-icons/Spring.svg"
+                  src="images/tech-stack-icons/Spring.svg"
                   alt="Spring Framework logo"
                   loading="lazy"
                 />
@@ -754,7 +754,7 @@
                 style="--reveal-delay: 0.22s"
               >
                 <img
-                  src="/images/tech-stack-icons/React.svg"
+                  src="images/tech-stack-icons/React.svg"
                   alt="React logo"
                   loading="lazy"
                 />
@@ -766,7 +766,7 @@
                 style="--reveal-delay: 0.27s"
               >
                 <img
-                  src="/images/tech-stack-icons/TypeScript.svg"
+                  src="images/tech-stack-icons/TypeScript.svg"
                   alt="TypeScript logo"
                   loading="lazy"
                 />
@@ -778,7 +778,7 @@
                 style="--reveal-delay: 0.32s"
               >
                 <img
-                  src="/images/tech-stack-icons/Node.js.svg"
+                  src="images/tech-stack-icons/Node.js.svg"
                   alt="Node.js logo"
                   loading="lazy"
                 />
@@ -790,7 +790,7 @@
                 style="--reveal-delay: 0.37s"
               >
                 <img
-                  src="/images/tech-stack-icons/Python.svg"
+                  src="images/tech-stack-icons/Python.svg"
                   alt="Python logo"
                   loading="lazy"
                 />
@@ -802,7 +802,7 @@
                 style="--reveal-delay: 0.42s"
               >
                 <img
-                  src="/images/tech-stack-icons/Docker.svg"
+                  src="images/tech-stack-icons/Docker.svg"
                   alt="Docker logo"
                   loading="lazy"
                 />
@@ -814,7 +814,7 @@
                 style="--reveal-delay: 0.47s"
               >
                 <img
-                  src="/images/tech-stack-icons/AWS.svg"
+                  src="images/tech-stack-icons/AWS.svg"
                   alt="AWS logo"
                   loading="lazy"
                 />
@@ -826,7 +826,7 @@
                 style="--reveal-delay: 0.52s"
               >
                 <img
-                  src="/images/tech-stack-icons/HashiCorp-Terraform.svg"
+                  src="images/tech-stack-icons/HashiCorp-Terraform.svg"
                   alt="Terraform logo"
                   loading="lazy"
                 />
@@ -838,7 +838,7 @@
                 style="--reveal-delay: 0.57s"
               >
                 <img
-                  src="/images/tech-stack-icons/PostgresSQL.svg"
+                  src="images/tech-stack-icons/PostgresSQL.svg"
                   alt="PostgreSQL logo"
                   loading="lazy"
                 />
@@ -850,7 +850,7 @@
                 style="--reveal-delay: 0.62s"
               >
                 <img
-                  src="/images/tech-stack-icons/MongoDB.svg"
+                  src="images/tech-stack-icons/MongoDB.svg"
                   alt="MongoDB logo"
                   loading="lazy"
                 />

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -19,7 +19,7 @@ const {
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="generator" content={Astro.generator} />
     <meta name="description" content={description} />
-    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+    <link rel="icon" type="image/svg+xml" href="favicon.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
@@ -30,6 +30,6 @@ const {
   </head>
   <body>
     <slot />
-    <script src="/js/main.js" type="module" defer></script>
+    <script src="js/main.js" type="module" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- update Astro build configuration to emit relative asset URLs for static hosting
- switch layout favicon and script references to relative paths
- update component image sources to load from relative paths so offline builds can find assets

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e036290ba083338f44cbcca9147c22