### PR TITLE
Ensure hero hero image remains circular in dev server

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -365,11 +365,15 @@ nav {
     rgba(14, 165, 233, 0.25)
   );
   box-shadow: 0 25px 45px rgba(99, 102, 241, 0.25);
+  width: min(280px, 60vw);
+  aspect-ratio: 1 / 1;
+  display: grid;
+  place-items: center;
 }
 
 .hero-profile img {
-  width: min(280px, 60vw);
-  aspect-ratio: 1 / 1;
+  width: 100%;
+  height: 100%;
   border-radius: 9999px;
   display: block;
   object-fit: cover;


### PR DESCRIPTION
## Summary
- enforce a square aspect ratio on the hero profile wrapper
- size the hero image via the wrapper so it stays circular in dev and preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e04232aa8c833385a91875bce3aa4a