### PR TITLE
Configure Astro base for GitHub Pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,9 +1,10 @@
 // @ts-check
 import react from '@astrojs/react';
-
 import { defineConfig } from 'astro/config';
 
 // https://astro.build/config
 export default defineConfig({
+  site: 'https://ahmed-marzook.github.io',
+  base: '/Ahmed-Portfolio',
   integrations: [react()],
 });


### PR DESCRIPTION
## Summary
- set the Astro `site` and `base` configuration to match the GitHub Pages deployment path so built assets resolve correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0465ccc248333b3b5dc7c1a265713