### PR TITLE
Fix tech icon image sources

### DIFF
--- a/src/components/welcome/AboutMeSection.tsx
+++ b/src/components/welcome/AboutMeSection.tsx
@@ -39,10 +39,12 @@ const AboutMeSection = () => (
       <div className={styles.aboutContent}>
         <div className={styles.aboutVisual} data-reveal="left">
           <img
-            src={heroPortrait}
+            src={heroPortrait.src}
             alt="Ahmed smiling"
             className={styles.aboutImage}
             loading="lazy"
+            width={heroPortrait.width}
+            height={heroPortrait.height}
           />
           <div className={styles.aboutQuote}>
             Always curious about the next clever workflow, the next elegant architecture, and the people who make both

--- a/src/components/welcome/FeaturedProjectsSection.tsx
+++ b/src/components/welcome/FeaturedProjectsSection.tsx
@@ -39,8 +39,10 @@ const projects: Project[] = [
     description:
       "A personalized birth plan generator that empowers families with curated, evidence-backed guidance. Includes dynamic questionnaires, shareable plans, and an empathetic experience for every stage of birth preparation.",
     image: {
-      src: birthYourWayImg,
+      src: birthYourWayImg.src,
       alt: "Birth Your Way birth plan generator placeholder",
+      width: birthYourWayImg.width,
+      height: birthYourWayImg.height,
     },
     tags: [
       { label: "React", iconKey: "react" },
@@ -59,8 +61,10 @@ const projects: Project[] = [
     description:
       "A dystopian spin on Hangman—each wrong guess wipes out a programming language, inching humanity toward an assembly-only future. Includes an interactive keyboard, language lore, and immersive animations.",
     image: {
-      src: lastLangImg,
+      src: lastLangImg.src,
       alt: "Screenshot from The Last High-Level Language game",
+      width: lastLangImg.width,
+      height: lastLangImg.height,
     },
     tags: [
       { label: "React", iconKey: "react" },
@@ -88,8 +92,10 @@ const projects: Project[] = [
     description:
       "A quick-hit dice game built to hone state management in React. Features animated rolls, streak tracking, celebratory confetti, and a fully responsive interface for desktop and mobile.",
     image: {
-      src: tenziesImg,
+      src: tenziesImg.src,
       alt: "Tenzies dice game interface",
+      width: tenziesImg.width,
+      height: tenziesImg.height,
     },
     tags: [
       { label: "React", iconKey: "react" },
@@ -113,8 +119,10 @@ const projects: Project[] = [
     description:
       "A Spring Boot service that aggregates Visual Crossing weather data with Redis caching to deliver fast, reliable forecasts. Features clean architecture, Terraform-managed AWS infrastructure, and automated CI/CD.",
     image: {
-      src: weatherBridgeImg,
+      src: weatherBridgeImg.src,
       alt: "WeatherBridge API dashboard placeholder",
+      width: weatherBridgeImg.width,
+      height: weatherBridgeImg.height,
     },
     tags: [
       { label: "Java", iconKey: "java" },

--- a/src/components/welcome/LandingHero.tsx
+++ b/src/components/welcome/LandingHero.tsx
@@ -62,7 +62,13 @@ const LandingHero = () => (
           style={{ "--reveal-delay": "0.15s" } as CSSProperties}
         >
           <div className={styles.heroProfile}>
-            <img src={heroPortrait} alt="Portrait of Ahmed Marzook" loading="eager" />
+            <img
+              src={heroPortrait.src}
+              alt="Portrait of Ahmed Marzook"
+              loading="eager"
+              width={heroPortrait.width}
+              height={heroPortrait.height}
+            />
           </div>
         </div>
       </div>

--- a/src/components/welcome/techIcons.ts
+++ b/src/components/welcome/techIcons.ts
@@ -16,22 +16,22 @@ import typescriptIcon from "../../assets/images/tech-stack-icons/TypeScript.svg"
 import viteIcon from "../../assets/images/tech-stack-icons/Vite.svg";
 
 const techIcons = {
-  aws: awsIcon,
-  azure: azureIcon,
-  docker: dockerIcon,
-  hashicorpTerraform: hashicorpTerraformIcon,
-  java: javaIcon,
-  javascript: javascriptIcon,
-  mongodb: mongodbIcon,
-  node: nodeIcon,
-  npm: npmIcon,
-  postgres: postgresIcon,
-  python: pythonIcon,
-  react: reactIcon,
-  redis: redisIcon,
-  spring: springIcon,
-  typescript: typescriptIcon,
-  vite: viteIcon,
+  aws: awsIcon.src,
+  azure: azureIcon.src,
+  docker: dockerIcon.src,
+  hashicorpTerraform: hashicorpTerraformIcon.src,
+  java: javaIcon.src,
+  javascript: javascriptIcon.src,
+  mongodb: mongodbIcon.src,
+  node: nodeIcon.src,
+  npm: npmIcon.src,
+  postgres: postgresIcon.src,
+  python: pythonIcon.src,
+  react: reactIcon.src,
+  redis: redisIcon.src,
+  spring: springIcon.src,
+  typescript: typescriptIcon.src,
+  vite: viteIcon.src,
 } as const;
 
 export type TechIconKey = keyof typeof techIcons;


### PR DESCRIPTION
## Summary
- point tech stack icon imports at their generated src URLs
- ensure featured project tags and skills icons render valid <img> sources

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e145aa250483339722bcc758cdb70d